### PR TITLE
Update PlayStationApiException.cs

### DIFF
--- a/PlayStationSharp/Exceptions/PlayStationApiException.cs
+++ b/PlayStationSharp/Exceptions/PlayStationApiException.cs
@@ -8,6 +8,9 @@ namespace PlayStationSharp.Exceptions
 	{
 		public Error Error;
 
-		public PlayStationApiException(Error error) => Error = error;
+		public PlayStationApiException(Error error) : base(error.Message)
+        {
+            Error = error;
+        }
 	}
 }


### PR DESCRIPTION
Allows the underlying error to be thrown when debugging. 
Errors such as "(2114059) Rate limit exceeded" aren't visible.